### PR TITLE
Fix for simplify subsumption from GHC 9.0

### DIFF
--- a/src/Data/Drinkery/Finite.hs
+++ b/src/Data/Drinkery/Finite.hs
@@ -44,22 +44,22 @@ concatMap f = go where
 {-# INLINE concatMap #-}
 
 filter :: Monad m => (a -> Bool) -> Pipe a a m
-filter = filtering . maybe True
+filter p = filtering (maybe True p)
 {-# INLINE filter #-}
 
 mapAccum :: Monad m => (s -> a -> (s, b)) -> s -> Pipe a b m
-mapAccum f = go where
+mapAccum f x = go x where
   go s = reservingTap $ \case
     Just a -> let (s', b) = f s a in return (Just b, go s')
     Nothing -> return (Nothing, go s)
 {-# INLINE mapAccum #-}
 
 traverse :: (Monad m) => (a -> m b) -> Pipe a b m
-traverse = traversing . Prelude.traverse
+traverse f = traversing (Prelude.traverse f)
 {-# INLINE traverse #-}
 
 take :: Monad m => Int -> Pipe a a m
-take = go where
+take x = go x where
   go 0 = repeatTap Nothing
   go n = reservingTap $ \a -> return (a, go (n - 1))
 {-# INLINE take #-}


### PR DESCRIPTION
failed to build drinkery with GHC 9.0

```
/path/to/drinkery/src/Data/Drinkery/Finite.hs:47:10: error:
    • Couldn't match type: Tap
                             r3 (Maybe a) (Sink (Tap r3 (Maybe a)) m2)
                     with: forall r. (Monoid r, Semigroup r) => Converter r a r a m
      Expected: (a -> Bool) -> Pipe a a m
        Actual: (a -> Bool)
                -> Distiller (Tap r3 (Maybe a)) r3 (Maybe a) m2
    • In the expression: filtering . maybe True
      In an equation for ‘Data.Drinkery.Finite.filter’:
          Data.Drinkery.Finite.filter = filtering . maybe True
    • Relevant bindings include
        filter :: (a -> Bool) -> Pipe a a m
          (bound at src/Data/Drinkery/Finite.hs:47:1)
   |
47 | filter = filtering . maybe True
   |          ^^^^^^^^^^^^^^^^^^^^^^

/path/to/drinkery/src/Data/Drinkery/Finite.hs:51:14: error:
    • Couldn't match type: Tap
                             r2 (Maybe b) (Sink (Tap r2 (Maybe a)) m1)
                     with: forall r. (Monoid r, Semigroup r) => Converter r a r b m
      Expected: s -> Pipe a b m
        Actual: s -> Distiller (Tap r2 (Maybe a)) r2 (Maybe b) m1
    • In the expression: go
      In an equation for ‘mapAccum’:
          mapAccum f
            = go
            where
                go s
                  = reservingTap
                      $ \case
                          Just a -> ...
                          Nothing -> return ...
    • Relevant bindings include
        go :: forall {m :: * -> *} {r}.
              Monad m =>
              s -> Distiller (Tap r (Maybe a)) r (Maybe b) m
          (bound at src/Data/Drinkery/Finite.hs:52:3)
        f :: s -> a -> (s, b) (bound at src/Data/Drinkery/Finite.hs:51:10)
        mapAccum :: (s -> a -> (s, b)) -> s -> Pipe a b m
          (bound at src/Data/Drinkery/Finite.hs:51:1)
   |
51 | mapAccum f = go where
   |              ^^
...
```

I think that this reason is "[Simplify subsumption](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0287-simplify-subsumption.rst)".
So, fix it with eta-expansion.